### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 **The first GPT-powered creative co-pilot trained on your actual LinkedIn content.**
 
+<a href="https://glama.ai/mcp/servers/@ertiqah/linkedin-mcp-runner">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ertiqah/linkedin-mcp-runner/badge" alt="LinkedIn Assistant MCP server" />
+</a>
+
 Create posts. Analyze what’s working. Rewrite in your voice. 
 All from Claude or ChatGPT, powered by your own past posts.
 


### PR DESCRIPTION
This PR adds a badge for the [LinkedIn MCP Assistant](https://glama.ai/mcp/servers/@ertiqah/linkedin-mcp-runner) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ertiqah/linkedin-mcp-runner">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ertiqah/linkedin-mcp-runner/badge" alt="LinkedIn Assistant MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.