### PR TITLE
fix: resolve Windows MCP auto-launch failures on Claude Desktop

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -39,11 +39,28 @@ function getConfigPath() {
     switch (platform) {
         case 'darwin':
             return path.join(os.homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
-        case 'win32':
+        case 'win32': {
             if (!process.env.APPDATA) {
                 console.error("Error: APPDATA environment variable not found."); process.exit(1);
             }
+            // Microsoft Store installations use a virtualized AppData path under LocalCache
+            const localAppData = process.env.LOCALAPPDATA;
+            if (localAppData) {
+                const packagesDir = path.join(localAppData, 'Packages');
+                try {
+                    const entries = fs.readdirSync(packagesDir);
+                    const claudePackage = entries.find(e => e.startsWith('Claude_'));
+                    if (claudePackage) {
+                        const msStorePath = path.join(packagesDir, claudePackage, 'LocalCache', 'Roaming', 'Claude', 'claude_desktop_config.json');
+                        const msStoreRoaming = path.join(packagesDir, claudePackage, 'LocalCache', 'Roaming');
+                        if (fs.existsSync(msStorePath) || fs.existsSync(msStoreRoaming)) {
+                            return msStorePath;
+                        }
+                    }
+                } catch (e) {}
+            }
             return path.join(process.env.APPDATA, 'Claude', 'claude_desktop_config.json');
+        }
         case 'linux':
              return path.join(os.homedir(), '.config', 'Claude', 'claude_desktop_config.json');
         default:
@@ -67,8 +84,10 @@ async function runSetup(apiKeyFromArg) {
     } catch (err) { console.error(`Error reading config: ${err}`); process.exit(1); }
     if (!configData.mcpServers) { configData.mcpServers = {}; }
     const apiKeyToUse = apiKeyFromArg || "PASTE_YOUR_API_KEY_HERE";
+    const isWindows = os.platform() === 'win32';
     configData.mcpServers['linkedin'] = {
-        command: "npx", args: ["-y", publishedPackageName],
+        command: isWindows ? "cmd" : "npx",
+        args: isWindows ? ["/c", "npx", "-y", publishedPackageName] : ["-y", publishedPackageName],
         env: { "LINKEDIN_MCP_API_KEY": apiKeyToUse }
     };
     try {


### PR DESCRIPTION
## Summary
- Use `cmd /c npx` instead of bare `npx` on Windows — Electron (Claude Desktop) cannot directly execute `.cmd` files and requires `cmd.exe` as the interpreter
- Detect Microsoft Store installations of Claude Desktop by checking `%LOCALAPPDATA%\Packages\Claude_*` for the virtualized AppData path, falling back to standard `%APPDATA%\Claude` for direct installer users

## Root Cause
Two separate bugs caused Windows users to see their config in Claude Desktop but never see LinkedIn/LiGo tools:
1. **Wrong config path** — MS Store version of Claude Desktop uses a virtualized AppData path that the setup script was not detecting
2. **Unspawnable command** — `npx` resolves to `npx.cmd` on Windows, which Electron cannot spawn directly without `cmd.exe`

## Test plan
- [ ] Run `npx linkedin-mcp-runner setup --api-key <key>` on Windows (direct installer) — verify config written to `%APPDATA%\Claude\` with `cmd /c npx` command
- [ ] Run setup on Windows with Claude Desktop installed via Microsoft Store — verify config written to `%LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude\`
- [ ] Restart Claude Desktop and confirm LinkedIn/LiGo tools appear
- [ ] Verify Mac/Linux behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)